### PR TITLE
fix: allow angular 8 or higher peer dependency

### DIFF
--- a/projects/ngx-rxjs-zone-scheduler/package.json
+++ b/projects/ngx-rxjs-zone-scheduler/package.json
@@ -14,8 +14,8 @@
   "homepage": "https://github.com/ftischler/ngx-rxjs-zone-scheduler/tree/master/projects/ngx-rxjs-zone-scheduler",
   "readme": "https://github.com/ftischler/ngx-rxjs-zone-scheduler/blob/master/projects/ngx-rxjs-zone-scheduler/README.md",
   "peerDependencies": {
-    "@angular/common": "^7.0.0",
-    "@angular/core": "^7.0.0",
+    "@angular/common": ">=7.0.0",
+    "@angular/core": ">=7.0.0",
     "rxjs": "^6.0.0"
   }
 }


### PR DESCRIPTION
Thanks for this lib, it was super helpful for solving some perf issues in our app in an elegant way 😄 I noticed that there was a peer dependency warning when installing it with angular 8, so this patch allows any version higher than 7