### PR TITLE
fix: allow newer zone.js versions in peer dependencies

### DIFF
--- a/projects/ngx-rxjs-zone-scheduler/package.json
+++ b/projects/ngx-rxjs-zone-scheduler/package.json
@@ -17,7 +17,7 @@
     "@angular/common": ">=7.0.0",
     "@angular/core": ">=7.0.0",
     "rxjs": "^6.0.0",
-    "zone.js": "~0.10.2"
+    "zone.js": ">=0.10.2"
   },
   "dependencies": {
     "tslib": "^2.0.0"


### PR DESCRIPTION
Angular 12 now relies on zone.js 0.11.x, so when using this package with it a peer dependency warning is created, this PR relaxes the restriction to allow newer versions 😄 